### PR TITLE
Removed js_of_ocaml-ppx dependency

### DIFF
--- a/incr_select.opam
+++ b/incr_select.opam
@@ -14,7 +14,6 @@ depends: [
   "ppx_driver"
   "ppx_jane"
   "jbuilder"                {build & >= "1.0+beta12"}
-  "js_of_ocaml-ppx"
   "ocaml-migrate-parsetree" {>= "1.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name incr_select)
   (public_name incr_select)
-  (preprocess (pps (js_of_ocaml-ppx ppx_jane ppx_driver.runner)))
+  (preprocess (pps (ppx_jane ppx_driver.runner)))
   (flags (:standard -safe-string))
   (libraries (core_kernel incremental_kernel))))
 


### PR DESCRIPTION
It seems like this package is pure Ocaml. Is `js_of_ocaml-ppx` an unnecessary dependency?